### PR TITLE
Increase PHP memory limit to 512M via FrankenPHP Caddyfile

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,5 +1,7 @@
 {
-	frankenphp
+	frankenphp {
+		php_ini memory_limit 512M
+	}
 	auto_https off
 }
 


### PR DESCRIPTION
This PR updates the Caddyfile to set the PHP memory_limit to 512M using the recommended FrankenPHP syntax. This change addresses Sentry issue CBZ-VIEWER-44 (Allowed memory size exhausted in image processing).\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>