### PR TITLE
Enable beta ecosystems in dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
+enable-beta-ecosystems: true # to manage bun's lockfile.
 registries:
   dhi:
     type: docker-registry


### PR DESCRIPTION
Enable beta ecosystems for managing bun's lockfile.